### PR TITLE
RELENG-2330 Replace the legacy /repo prefix in the Artifactory URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2017 ForgeRock AS.
+ * Copyright 2017-2023 ForgeRock AS.
  * 
 -->
 
@@ -79,7 +79,7 @@
 	      </snapshots>
 	      <id>forgerock-internal-releases</id>
 	      <name>ForgeRock Release Repository</name>
-	      <url>http://maven.forgerock.org/repo/internal-releases</url>
+	      <url>https://maven.forgerock.org/artifactory/internal-releases</url>
 	    </repository>
 	    <repository>
 	      <snapshots>
@@ -87,7 +87,7 @@
 	      </snapshots>
 	      <id>forgerock-private-releases</id>
 	      <name>ForgeRock Private Release Repository</name>
-	      <url>http://maven.forgerock.org/repo/private-releases</url>
+	      <url>https://maven.forgerock.org/artifactory/private-releases</url>
 	    </repository>
 	    <repository>
 	      <releases>
@@ -98,7 +98,7 @@
 	      </snapshots>
 	      <id>forgerock-internal-snapshots</id>
 	      <name>ForgeRock Snapshot Repository</name>
-	      <url>http://maven.forgerock.org/repo/internal-snapshots</url>
+	      <url>https://maven.forgerock.org/artifactory/internal-snapshots</url>
 	    </repository>
 	    <repository>
 	      <releases>
@@ -109,7 +109,7 @@
 	      </snapshots>
 	      <id>maven.forgerock.org</id>
 	      <name>maven.forgerock.org-openam-dependencies</name>
-	      <url>http://maven.forgerock.org/repo/openam-dependencies</url>
+	      <url>https://maven.forgerock.org/artifactory/openam-dependencies</url>
 	    </repository>
 	    <repository>
 	      <releases>
@@ -120,7 +120,7 @@
 	      </snapshots>
 	      <id>restlet-cache</id>
 	      <name>Restlet Cache Repository</name>
-	      <url>http://maven.forgerock.org/repo/maven.restlet.org</url>
+	      <url>https://maven.forgerock.org/artifactory/maven.restlet.org</url>
 	    </repository>
 	    <repository>
 	      <snapshots>
@@ -133,7 +133,7 @@
 	    <repository>
 	      <id>forgerock-internal</id>
 	      <name>Forgerock Internal Repository</name>
-	      <url>http://maven.forgerock.org/repo/internal</url>
+	      <url>https://maven.forgerock.org/artifactory/internal</url>
 	    </repository>
 	    <repository>
 	      <snapshots>


### PR DESCRIPTION
Hi,
The ForgeRock Artifactory instance will soon move to the JFrog.io SaaS.
The URL will remain the same but the /repo prefix won't work anymore.
Thanks,
Bruno Lavit, release manager at ForgeRock